### PR TITLE
Add New relic install and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ For Mapathon :
 
 ```from galaxy import Mapathon```
 ##### You can see sample for mapathon in tests/src/terminal.py
+
+## New Relic
+When using New Relic, save the newrelic.ini to the root of the project and run the following to start the server:
+
+```NEW_RELIC_CONFIG_FILE=newrelic.ini $PATH_TO_BIN/newrelic-admin run-program $PATH_TO_BIN/uvicorn API.main:app```

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,8 @@ testing.postgresql==1.3.0
 pandas == 1.3.4
 numpy == 1.17.3
 geojson == 2.5.0
+# Used for new relic monitoring
+newrelic == 7.2.4.171
 # '''required for generating documentations '''
 sphinx_rtd_theme==1.0.0
 sphinx==4.2.0


### PR DESCRIPTION
Tested locally and was able to get data into new relic. We will need to add a wrapper to the server supervisor command as follows: 

```
environment=NEW_RELIC_CONFIG_FILE=$PROJECT_ROOT/newrelic.ini
command=$INSTALL_PATH/newrelic-admin run-program /home/ubuntu/env/bin/uvicorn --fd 0 API.main:app
````