### PR TITLE
Update numpy version to 1.19.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ itsdangerous==2.0.1
 pytest == 3.7
 testing.postgresql==1.3.0
 pandas == 1.3.4
-numpy == 1.17.3
+numpy == 1.19.3
 geojson == 2.5.0
 # '''required for generating documentations '''
 sphinx_rtd_theme==1.0.0


### PR DESCRIPTION
Fixes compatibility error with pandas:

```
ERROR: Cannot install numpy==1.17.3 and pandas==1.3.4 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested numpy==1.17.3
    pandas 1.3.4 depends on numpy>=1.19.2; platform_machine == "aarch64" and python_version < "3.10"

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
```

